### PR TITLE
Feature - Add overflow: auto to FilterEditModal to allow a lot of predicates to be displayed

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -64,7 +64,7 @@ export const Modal = observer(({ children, onClose }: IProps) => {
         <span className="mr-2">Close</span>
         <i className="fa fa-times" />
       </div>
-      <Wrapper>{children}</Wrapper>
+      <Wrapper className="h-full overflow-auto">{children}</Wrapper>
     </Backdrop>
   );
 });

--- a/src/containers/FilterEditModal/FilterEditModal.tsx
+++ b/src/containers/FilterEditModal/FilterEditModal.tsx
@@ -50,7 +50,7 @@ export const FilterEditModal = observer(
 
     return (
       <Modal onClose={onClose}>
-        <Container className="mt-32 mx-auto">
+        <Container className="mt-32 mb-16 mx-auto">
           {step === STEPS.PROVIDERS && (
             <ProviderStep
               provider={provider}


### PR DESCRIPTION
**description**
When you add lots of predicates to a filter, you will not be able to add more predicate or access the CTAs "Cancel" / "Continue" as they will be rendered outside of the viewport, as no scroll is made available to the user.

<img width="1440" alt="Screenshot 2019-08-20 at 13 52 03" src="https://user-images.githubusercontent.com/4000576/63344924-e3047c00-c351-11e9-8163-f59f5bf5608e.png">

**solution**
This PR adds the necessary classes to the Modal component content Wrapper to allow for its content to provide a scrollbar if the content is overflowing.
In extra, it also adds spacing at the bottom of the FilterEditModal, between the CTAs and the bottom of the screen.

<img width="1440" alt="Screenshot 2019-08-20 at 13 52 15" src="https://user-images.githubusercontent.com/4000576/63344952-e992f380-c351-11e9-8e8b-1269ca578134.png">
